### PR TITLE
Anony mouse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM gcc:latest AS compiler
-#RUN ["mkdir -p /usr"]
-WORKDIR /usr
-COPY src .
-COPY inc .
-COPY lib .
+RUN ["mkdir", "-p", "/usr/dev"]
+WORKDIR /usr/dev
+COPY src src
+COPY inc inc
+COPY lib lib
 COPY makefile .
 CMD ["make"]
 

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ LDIR_INC = ${LDIR}/inc
 # Set compiler settings
 CC = gcc
 LIBS = 
-CFLAGS = -I${IDIR} -Wall -Wextra -Werror
+CFLAGS = -I ${IDIR} -Wall -Wextra -Werror
 LDFLAGS = 
 
 # Name binary executable
@@ -26,7 +26,7 @@ LLIB = $(patsubst %,${ODIR_LIB}/%,${_LLIB})
 
 # Build dependencies list
 _DEPS = input.h
-DEPS = $(patsubst %,${IDIR}/%,${_DEPS})
+DEPS=$(patsubst %,${IDIR}/%,${_DEPS})
 
 # Catch for make all
 .PHONY: all
@@ -50,11 +50,11 @@ ${ODIR_LIB}/%.o: ${LDIR}/%.c ${LDIR_INC}/%.h
 .PHONY: install
 install: all
 	@echo "You must be root to install."
-	chmod +x tmcast
-	mv ${ODIR}/binary /usr/local/bin/tmcast
+	chmod +x ${EXE}
+	cp ${EXE} /usr/local/bin/tmcast
 
 # Clean up build files and folders
 .PHONY: clean
 clean:
-	-rm -f ${ODIR}/binary ${ODIR}/*.o ${ODIR_LIB}/.o *~ core ${IDIR}/*~ ${LDIR}/*~ ${LDIR_INC}/*~
+	-rm -f ${EXE} ${ODIR}/*.o ${ODIR_LIB}/.o *~ core ${IDIR}/*~ ${LDIR}/*~ ${LDIR_INC}/*~
 	-rm -rf ${ODIR}

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ LDIR_INC = ${LDIR}/inc
 # Set compiler settings
 CC = gcc
 LIBS = 
-CFLAGS = -I ${IDIR} -Wall -Wextra -Werror
+CFLAGS = -I ${IDIR} -I ${LDIR_INC} -Wall -Wextra -Werror
 LDFLAGS = 
 
 # Name binary executable


### PR DESCRIPTION
## Title: Fixed Build

### Scope:
Diagnosed and resolved the Docker build issues

### Description:
Included library headers in the compiler flags in the makefile, resolved the folder structure issue in the Dockerfile so the test environment now successfully builds and attempts to compile the program.

### Oustanding:
Eldrytch source code compiler error horror from gcc docker container, to resolve:
```c
mkdir -p ./build
gcc -c src/main.c -I ./inc -I ./lib/inc -Wall -Wextra -Werror -o build/main.o
In file included from src/main.c:2:
./inc/input.h:18:17: error: unknown type name 'flagTupleNode'
   18 | bool write_node(flagTupleNode *ptrNode);
      |                 ^~~~~~~~~~~~~
src/main.c: In function 'main':
src/main.c:40:20: error: redeclaration of 'flagTable' with no linkage
   40 |     flagTupleNode *flagTable[UINT_MAX + 1] = {NULL};
      |                    ^~~~~~~~~
src/main.c:39:20: note: previous declaration of 'flagTable' with type 'flagTupleNode *[0]'
   39 |     flagTupleNode *flagTable[UINT_MAX + 1];
      |                    ^~~~~~~~~
src/main.c:40:47: error: excess elements in array initializer [-Werror]
   40 |     flagTupleNode *flagTable[UINT_MAX + 1] = {NULL};
      |                                               ^~~~
src/main.c:40:47: note: (near initialization for 'flagTable')
src/main.c:49:10: error: 'i' undeclared (first use in this function)
   49 |     for (i = 1; i < argc; i++)
      |          ^
src/main.c:49:10: note: each undeclared identifier is reported only once for each function it appears in
src/main.c:62:18: error: 'j' undeclared (first use in this function)
   62 |             for (j = 1; j < LEN(arg[j]); j++)
      |                  ^
In file included from src/main.c:2:
src/main.c:62:33: error: 'arg' undeclared (first use in this function); did you mean 'argv'?
   62 |             for (j = 1; j < LEN(arg[j]); j++)
      |                                 ^~~
./inc/input.h:12:24: note: in definition of macro 'LEN'
   12 | #define LEN(a) (sizeof(a) / sizeof(*a)) // Define array length
      |                        ^
src/main.c:40:20: error: unused variable 'flagTable' [-Werror=unused-variable]
   40 |     flagTupleNode *flagTable[UINT_MAX + 1] = {NULL};
      |                    ^~~~~~~~~
cc1: all warnings being treated as errors
make: *** [makefile:42: build/main.o] Error 1
```