### PR TITLE
fixed compilation errors

### DIFF
--- a/inc/input.h
+++ b/inc/input.h
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <string.h>
 #include <limits.h>
 
 // Local files
@@ -9,7 +10,6 @@
 
 // Definitions
 #define MAX 10000                       // Set upper bound
-#define LEN(a) (sizeof(a) / sizeof(*a)) // Define array length
 #define NUM_FLAGS 1                     // Set number of flags
 
 // Function prototypes

--- a/src/main.c
+++ b/src/main.c
@@ -46,10 +46,13 @@ int main(int argc, const char *argv[])
     }
     
     // Iterate over arguments
-    for (i = 1; i < argc; i++)
+    for (int i = 1; i < argc; i++)
     {
-        // Sanitize arguments
-        if (LEN(argv[i]) < 1 || LEN(argv[i]) > MAX)
+        count = 0;
+	while(argv[i][++count] != '\0');
+	    
+	// Sanitize arguments
+        if (count < 1 || count > MAX)
         {
             printf("Arguments too long.\n");
             return 102;
@@ -59,35 +62,35 @@ int main(int argc, const char *argv[])
         if (argv[i][0] == '-')
         {
             // Identify flags
-            for (j = 1; j < LEN(arg[j]); j++)
+            for (int j = 1; j < count; j++)
             {
                 // Catch long form flags
                 if (j == 1 && argv[i][j] == '-')
                 {
                     // Detect long form flags
-                    switch (argv[i])
+                    if (strcmp(argv[i], "--version") == 0)
                     {
-                        case "--version":
                             // Set boolean of preset struct to true
-                            break;
-                        
-                        default:
+		    }
+                    
+		    // Catch invalid flags 
+		    else
+		    {
                             printf("Invalid flag %s.\n", argv[i]);
                             return 201;
                     }
-                    break;
                 }
                 else
                 {
                     // Detect short form flags
-                    switch (argv[i][j])
+                    if (argv[i][j] == 'v')
                     {
-                        case 'v':
                             // Set boolean of preset struct to true
-                            break;
-
-                        // Catch invalid flags
-                        default:
+                    }
+                    
+		    // Catch invalid flags
+		    else
+		    {
                             printf("Invalid flag -%c.\n", argv[i][j]);
                             return 201;
                     }


### PR DESCRIPTION
## Title: Fix basic compilation issues

### Scope:
Resolve all the non struct related compiler errors

### Description:
Removed LEN, replaced with count, removed the switch statements as string cannot be condensed to an int, fixed a couple of typos and a couple of missing assignment types, replaced pointer validation with comparison to string equivalent, swapped boolean comparison to string compare, added in missing include to string.h

### Oustanding:
```c
mkdir -p ./build
gcc -c src/main.c -I ./inc -I ./lib/inc -Wall -Wextra -Werror -o build/main.o
In file included from src/main.c:2:
./inc/input.h:18:17: error: unknown type name 'flagTupleNode'
   18 | bool write_node(flagTupleNode *ptrNode);
      |                 ^~~~~~~~~~~~~
src/main.c: In function 'main':
src/main.c:40:20: error: redeclaration of 'flagTable' with no linkage
   40 |     flagTupleNode *flagTable[UINT_MAX + 1] = {NULL};
      |                    ^~~~~~~~~
src/main.c:39:20: note: previous declaration of 'flagTable' with type 'flagTupleNode *[0]'
   39 |     flagTupleNode *flagTable[UINT_MAX + 1];
      |                    ^~~~~~~~~
src/main.c:40:47: error: excess elements in array initializer [-Werror]
   40 |     flagTupleNode *flagTable[UINT_MAX + 1] = {NULL};
      |                                               ^~~~
src/main.c:40:47: note: (near initialization for 'flagTable')
src/main.c:40:20: error: unused variable 'flagTable' [-Werror=unused-variable]
   40 |     flagTupleNode *flagTable[UINT_MAX + 1] = {NULL};
      |                    ^~~~~~~~~
cc1: all warnings being treated as errors
make: *** [makefile:42: build/main.o] Error 1
```
